### PR TITLE
Added a pool to the run file

### DIFF
--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -7,7 +7,9 @@ USER=airflow
 DAEMON=airflow
 EXEC=$(which $DAEMON)
 START_COMMAND="${EXEC} webserver | tee /opt/bitnami/airflow/logs/airflow-webserver.log"
-
+if [ $AIRFLOW_POOL ]; then
+    CREATE_POOL="${EXEC} pool -s $AIRFLOW_POOL_NAME $AIRFLOW_POOL_SIZE $AIRFLOW_POOL_DESCRIPTION | tee /opt/bitnami/airflow/logs/airflow-webserver.log"
+fi
 echo "Waiting for db..."
 counter=0;
 res=1000;
@@ -27,6 +29,12 @@ info "Starting ${DAEMON}..."
 # If container is started as `root` user
 if [ $EUID -eq 0 ]; then
     exec gosu ${USER} bash -c "${START_COMMAND}"
+    if [ $AIRFLOW_POOL ]; then
+	exec gosu ${USER} bash -c "${CREATE_POOL}"
+    fi
 else
     exec bash -c "${START_COMMAND}"
+    if [ $AIRFLOW_POOL ]; then
+	exec bash -c "${CREATE_POOL}"
+    fi
 fi

--- a/1/debian-9/rootfs/run.sh
+++ b/1/debian-9/rootfs/run.sh
@@ -28,13 +28,13 @@ done
 info "Starting ${DAEMON}..."
 # If container is started as `root` user
 if [ $EUID -eq 0 ]; then
-    exec gosu ${USER} bash -c "${START_COMMAND}"
     if [ $AIRFLOW_POOL ]; then
-	exec gosu ${USER} bash -c "${CREATE_POOL}"
+	gosu ${USER} bash -c "${CREATE_POOL}"
     fi
-else
-    exec bash -c "${START_COMMAND}"
+	exec gosu ${USER} bash -c "${START_COMMAND}"
+    else
     if [ $AIRFLOW_POOL ]; then
-	exec bash -c "${CREATE_POOL}"
+	bash -c "${CREATE_POOL}"
     fi
-fi
+	exec bash -c "${START_COMMAND}"
+    fi

--- a/1/ol-7/rootfs/run.sh
+++ b/1/ol-7/rootfs/run.sh
@@ -23,6 +23,10 @@ do
     sleep 1
 done
 
+if [[ -n "$AIRFLOW_POOL_NAME" ]] && [[ -n "$AIRFLOW_POOL_SIZE" ]] && [[ -n "$AIRFLOW_POOL_DESC" ]]; then
+    ${EXEC} pool -s "$AIRFLOW_POOL_NAME" "$AIRFLOW_POOL_SIZE" "$AIRFLOW_POOL_DESC"
+fi
+
 info "Starting ${DAEMON}..."
 # If container is started as `root` user
 if [ $EUID -eq 0 ]; then

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ $ docker-compose up
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/).
 
 
-* [`1-ol-7`, `1.10.6-ol-7-r19` (1/ol-7/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-ol-7-r19/1/ol-7/Dockerfile)
-* [`1-debian-9`, `1.10.6-debian-9-r11`, `1`, `1.10.6`, `1.10.6-r11`, `latest` (1/debian-9/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-debian-9-r11/1/debian-9/Dockerfile)
+* [`1-ol-7`, `1.10.6-ol-7-r32` (1/ol-7/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-ol-7-r32/1/ol-7/Dockerfile)
+* [`1-debian-9`, `1.10.6-debian-9-r21`, `1`, `1.10.6`, `1.10.6-r21`, `latest` (1/debian-9/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-debian-9-r21/1/debian-9/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/airflow GitHub repo](https://github.com/bitnami/bitnami-docker-airflow).
 
@@ -316,6 +316,9 @@ The Airflow instance can be customized by specifying environment variables on th
 - `AIRFLOW_LOAD_EXAMPLES`: To load example tasks into the application. Default: **yes**
 - `AIRFLOW_BASE_URL`: Airflow webserver base URL. No defaults.
 - `AIRFLOW_HOSTNAME_CALLABLE`: Method to obtain the hostname. No defaults.
+- `AIRFLOW_POOL_NAME`: Pool name. No defaults.
+- `AIRFLOW_POOL_SIZE`: Pool size, required with `AIRFLOW_POOL_NAME`. No defaults.
+- `AIRFLOW_POOL_DESC`: Pool description, required with `AIRFLOW_POOL_NAME`. No defaults.
 
 ##### Use an existing database
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ $ docker-compose up
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/).
 
 
-* [`1-ol-7`, `1.10.6-ol-7-r32` (1/ol-7/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-ol-7-r32/1/ol-7/Dockerfile)
-* [`1-debian-9`, `1.10.6-debian-9-r21`, `1`, `1.10.6`, `1.10.6-r21`, `latest` (1/debian-9/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-debian-9-r21/1/debian-9/Dockerfile)
+* [`1-ol-7`, `1.10.6-ol-7-r19` (1/ol-7/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-ol-7-r19/1/ol-7/Dockerfile)
+* [`1-debian-9`, `1.10.6-debian-9-r11`, `1`, `1.10.6`, `1.10.6-r11`, `latest` (1/debian-9/Dockerfile)](https://github.com/bitnami/bitnami-docker-airflow/blob/1.10.6-debian-9-r11/1/debian-9/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/airflow GitHub repo](https://github.com/bitnami/bitnami-docker-airflow).
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Made it possible to specify an additional pool to be created when airflow is launched.

**Benefits**

An additional pool will be useful for separating the tasks into workloads.

**Possible drawbacks**

None that I can think of

**Applicable issues**

Not entirely sure what would happen if you try to run airflow, but the additional pool you're trying to create is already specified.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
