### PR TITLE
Added support for non-standard postgres port in initial connectivity check

### DIFF
--- a/1/debian-10/rootfs/run.sh
+++ b/1/debian-10/rootfs/run.sh
@@ -13,7 +13,7 @@ counter=0;
 res=1000;
 while [[ $res != 0 && $counter -lt 30 ]];
 do
-    if PGPASSWORD=$AIRFLOW_DATABASE_PASSWORD psql -h "$AIRFLOW_DATABASE_HOST" -U "$AIRFLOW_DATABASE_USERNAME" -d "$AIRFLOW_DATABASE_NAME" -c "" > /dev/null ; then
+    if PGPASSWORD=$AIRFLOW_DATABASE_PASSWORD psql -h "$AIRFLOW_DATABASE_HOST" -U "$AIRFLOW_DATABASE_USERNAME" -d "$AIRFLOW_DATABASE_NAME" -c "" -p "$AIRFLOW_DATABASE_PORT_NUMBER" > /dev/null ; then
         echo "Database is ready";
         res=0
     else

--- a/1/ol-7/rootfs/run.sh
+++ b/1/ol-7/rootfs/run.sh
@@ -13,7 +13,7 @@ counter=0;
 res=1000;
 while [[ $res != 0 && $counter -lt 30 ]];
 do
-    if PGPASSWORD=$AIRFLOW_DATABASE_PASSWORD psql -h "$AIRFLOW_DATABASE_HOST" -U "$AIRFLOW_DATABASE_USERNAME" -d "$AIRFLOW_DATABASE_NAME" -c "" > /dev/null ; then
+    if PGPASSWORD=$AIRFLOW_DATABASE_PASSWORD psql -h "$AIRFLOW_DATABASE_HOST" -U "$AIRFLOW_DATABASE_USERNAME" -d "$AIRFLOW_DATABASE_NAME" -c "" -p "$AIRFLOW_DATABASE_PORT_NUMBER" > /dev/null ; then
         echo "Database is ready";
         res=0
     else


### PR DESCRIPTION
**Description of the change**

added support for non default port number for psql connectivity check.

**Benefits**

I can run external postgres on different port than 5432 

**Possible drawbacks**

none

**Applicable issues**

None 
**Additional information**

?