### PR TITLE
Adds the possibility to inject python modules

### DIFF
--- a/1/debian-10/rootfs/run.sh
+++ b/1/debian-10/rootfs/run.sh
@@ -9,9 +9,9 @@ EXEC=$(which $DAEMON)
 START_COMMAND="${EXEC} webserver | tee /opt/bitnami/airflow/logs/airflow-webserver.log"
 
 # Install custom python package if requirements.txt is present
-if [ -e "/requirements.txt" ]; then
+if [ -e "/bitnami/python/requirements.txt" ]; then
     source /opt/bitnami/airflow/venv/bin/activate
-    pip install -r /requirements.txt
+    pip install -r /bitnami/python/requirements.txt
     deactivate
 fi
 

--- a/1/debian-10/rootfs/run.sh
+++ b/1/debian-10/rootfs/run.sh
@@ -8,6 +8,13 @@ DAEMON=airflow
 EXEC=$(which $DAEMON)
 START_COMMAND="${EXEC} webserver | tee /opt/bitnami/airflow/logs/airflow-webserver.log"
 
+# Install custom python package if requirements.txt is present
+if [ -e "/requirements.txt" ]; then
+    source /opt/bitnami/airflow/venv/bin/activate
+    pip install -r /requirements.txt
+    deactivate
+fi
+
 echo "Waiting for db..."
 counter=0;
 res=1000;


### PR DESCRIPTION
**Description of the change**
Sometimes Airflow plugins need Third-Party Python Libraries. This commit introduces a way to inject the dependencies via a requirements.txt file which can be mounted as a docker volume.

**Benefits**
With this new feature in place, there is no custom rebuild necessary for adding Airflow plugins which use Third-Party Libraries.

**Applicable issues**
Fixes #32

Signed-off-by: Jürgen Löhel <juergen@loehel.de>


