### PR TITLE
Fix AUTH_LDAP is not defined issue

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -261,8 +261,8 @@ airflow_configure_webserver_authentication() {
 
     if is_boolean_yes "$AIRFLOW_LDAP_ENABLE"; then
         info "Enabling LDAP authentication"
-        replace_in_file "$AIRFLOW_WEBSERVER_CONF_FILE" "# from flask_appbuilder.security.manager import AUTH_LDAP" "from flask_appbuilder.security.manager import AUTH_LDAP"
-        replace_in_file "$AIRFLOW_WEBSERVER_CONF_FILE" "from flask_appbuilder.security.manager import AUTH_DB" "# from flask_appbuilder.security.manager import AUTH_DB"
+        replace_in_file "$AIRFLOW_WEBSERVER_CONF_FILE" "# from airflow.www.fab_security.manager import AUTH_LDAP" "from airflow.www.fab_security.manager import AUTH_LDAP"
+        replace_in_file "$AIRFLOW_WEBSERVER_CONF_FILE" "from airflow.www.fab_security.manager import AUTH_DB" "# from airflow.www.fab_security.manager import AUTH_DB"
 
         # webserver config
         airflow_webserver_conf_set "AUTH_TYPE" "AUTH_LDAP"

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -261,6 +261,7 @@ airflow_configure_webserver_authentication() {
 
     if is_boolean_yes "$AIRFLOW_LDAP_ENABLE"; then
         info "Enabling LDAP authentication"
+        # These values changed in 2.2.0 (PR https://github.com/apache/airflow/pull/16647)
         replace_in_file "$AIRFLOW_WEBSERVER_CONF_FILE" "# from airflow.www.fab_security.manager import AUTH_LDAP" "from airflow.www.fab_security.manager import AUTH_LDAP"
         replace_in_file "$AIRFLOW_WEBSERVER_CONF_FILE" "from airflow.www.fab_security.manager import AUTH_DB" "# from airflow.www.fab_security.manager import AUTH_DB"
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

In airflow configuration file the syntax is changed what the code is trying to comment/uncomment here (https://github.com/bitnami/bitnami-docker-airflow/blob/master/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh#L264), if you check the current image from docker hub it has this format:
`from airflow.www.fab_security.manager import AUTH_LDAP`

The change is related to this upstream pull request https://github.com/apache/airflow/pull/16647

**Benefits**

Ldap authentication will work again.

**Possible drawbacks**

This is a simple fix, no drawbacks should be

**Applicable issues**

#112 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
