### PR TITLE
Updated environment variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you want to run the application manually instead of using `docker-compose`, t
     -e AIRFLOW_DATABASE_USERNAME=bn_airflow \
     -e AIRFLOW_DATABASE_PASSWORD=bitnami1 \
     -e AIRFLOW_LOAD_EXAMPLES=yes \
-    -e AIRFLOW_WEBSERVER_HOST=127.0.0.1 \
+    -e AIRFLOW_WEBSERVER_HOST=airflow \
     --net airflow-tier \
     --volume airflow_scheduler_data:/bitnami \
     bitnami/airflow-scheduler:latest
@@ -141,7 +141,7 @@ If you want to run the application manually instead of using `docker-compose`, t
     -e AIRFLOW_DATABASE_NAME=bitnami_airflow \
     -e AIRFLOW_DATABASE_USERNAME=bn_airflow \
     -e AIRFLOW_DATABASE_PASSWORD=bitnami1 \
-    -e AIRFLOW_WEBSERVER_HOST=127.0.0.1 \
+    -e AIRFLOW_WEBSERVER_HOST=airflow \
     --net airflow-tier \
     --volume airflow_worker_data:/bitnami \
     bitnami/airflow-worker:latest
@@ -282,6 +282,7 @@ services:
     -e AIRFLOW_DATABASE_USERNAME=bn_airflow \
     -e AIRFLOW_DATABASE_PASSWORD=bitnami1 \
     -e AIRFLOW_LOAD_EXAMPLES=yes \
+    -e AIRFLOW_WEBSERVER_HOST=airflow \
     --net airflow-tier \
     --volume /path/to/airflow-scheduler-persistence:/bitnami \
     bitnami/airflow-scheduler:latest
@@ -297,6 +298,7 @@ services:
     -e AIRFLOW_DATABASE_NAME=bitnami_airflow \
     -e AIRFLOW_DATABASE_USERNAME=bn_airflow \
     -e AIRFLOW_DATABASE_PASSWORD=bitnami1 \
+    -e AIRFLOW_WEBSERVER_HOST=airflow \
     --net airflow-tier \
     --volume /path/to/airflow-worker-persistence:/bitnami \
     bitnami/airflow-worker:latest


### PR DESCRIPTION
**Scope**
Extremely little. README update.

**Limitations**

None known. This fixes a known bug as shown in the related issues below.


**Description of the change**

I added / changed the environment variable `AIRFLOW_WEBSERVER_HOST=airflow`  for the airflow worker / scheduler services in the docker cli instructions to resolve an issue with the current version. In the current version, one is unable to run any DAGS due to a known issue with that environment variable being incorrect. The issue one would get is:  `timeout reached before the port went into state "inuse"`.

**Benefits**

This will make following the docker cli guide on the README work without issue!

**Possible drawbacks**

None! 

**Applicable issues**

https://github.com/bitnami/bitnami-docker-airflow/issues/78
https://github.com/bitnami/bitnami-docker-airflow/issues/87

**Additional information**
N/A
